### PR TITLE
Work

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,11 +6,3 @@ COPY *.go ./
 RUN go build -o /api
 EXPOSE 8000
 CMD ["./api"]
-
-#COPY go.mod ./
-#COPY go.mod go.sum ./
-#RUN go mod download
-#COPY *.go ./
-#RUN CGO_ENABLED=0 GOOS=linux go build -o /docker-gs-ping
-#EXPOSE 8000
-#CMD ["/docker-gs-ping"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.24.1
+WORKDIR /api
+COPY go.mod go.sum ./
+RUN go mod download
+COPY *.go ./
+RUN go build -o /api
+EXPOSE 8000
+CMD ["./api"]
+
+#COPY go.mod ./
+#COPY go.mod go.sum ./
+#RUN go mod download
+#COPY *.go ./
+#RUN CGO_ENABLED=0 GOOS=linux go build -o /docker-gs-ping
+#EXPOSE 8000
+#CMD ["/docker-gs-ping"]

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,0 +1,8 @@
+module api
+
+go 1.24.1
+
+require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/gorilla/mux v1.8.1
+)

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,0 +1,4 @@
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/api/main.go
+++ b/api/main.go
@@ -51,7 +51,7 @@ func reportsHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, "Token ERROR!")
+		fmt.Fprint(w, "Token ERROR! " + err.Error())
 		return
 	}
 

--- a/api/main.go
+++ b/api/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"github.com/gorilla/mux"
+	"github.com/dgrijalva/jwt-go"
+)
+
+var mySigningKey = []byte("oNwoLQdvJAvRcL89SydqCWCe5ry1jMgq")
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/reports", reportsHandler).Methods("GET")
+	http.ListenAndServe(":8000", r)
+}
+
+func reportsHandler(w http.ResponseWriter, r *http.Request) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		http.Error(w, "Authorization header is required", http.StatusUnauthorized)
+		return
+	}
+
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return mySigningKey, nil
+	})
+
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, "Token ERROR" )
+		return
+	}
+
+	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		if claims["roles"] != "prothetic_user" {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, "Need role is nothing")
+			return
+		}
+		fmt.Fprint(w, "OK - WELCOME - " + tokenString)
+	} else {		
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, "Token not valid")
+	}	
+
+}

--- a/api/main.go
+++ b/api/main.go
@@ -4,16 +4,34 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"github.com/gorilla/mux"
 	"github.com/dgrijalva/jwt-go"
+	"github.com/gorilla/mux"
 )
+
+// CORSMiddleware добавляет необходимые заголовки для поддержки CORS
+func CORSMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")                            // Разрешаем все источники (для разработки)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")          // Разрешаем методы
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization") // Разрешаем заголовки
+
+		if r.Method == http.MethodOptions {
+			// Обработка preflight-запросов
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next.ServeHTTP(w, r) // Передаем управление следующему обработчику
+	})
+}
 
 var mySigningKey = []byte("oNwoLQdvJAvRcL89SydqCWCe5ry1jMgq")
 
 func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/reports", reportsHandler).Methods("GET")
-	http.ListenAndServe(":8000", r)
+	// Оборачиваем маршрутизатор в middleware CORS
+	http.ListenAndServe(":8000", CORSMiddleware(r))
 }
 
 func reportsHandler(w http.ResponseWriter, r *http.Request) {
@@ -33,20 +51,20 @@ func reportsHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, "Token ERROR" )
+		fmt.Fprint(w, "Token ERROR!")
 		return
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
 		if claims["roles"] != "prothetic_user" {
 			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Fprint(w, "Need role is nothing")
+			fmt.Fprint(w, "Target role not found!")
 			return
 		}
-		fmt.Fprint(w, "OK - WELCOME - " + tokenString)
-	} else {		
+		fmt.Fprint(w, "OK - WELCOME!")
+	} else {
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, "Token not valid")
-	}	
+		fmt.Fprint(w, "Token not valid!")
+	}
 
 }

--- a/api/main.go
+++ b/api/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
 )
@@ -25,47 +26,47 @@ func CORSMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-var mySigningKey = []byte("oNwoLQdvJAvRcL89SydqCWCe5ry1jMgq")
-
 func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/reports", reportsHandler).Methods("GET")
-	// Оборачиваем маршрутизатор в middleware CORS
 	http.ListenAndServe(":8000", CORSMiddleware(r))
 }
 
+var publicKey = []byte("\n-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1mxs5cw/bOGQ+PHLFeIwDAUzGhKLDYbNJaqoHjvV/GUCAp/1FF/TDIiEN2fuLLeAgpPZKZSEG+bxXJ7vXXxSNvUjY1etmRvHbhlMN+rJYTQtWLZxsvM/MfYi0b+l20oeGtCBwUa2CKWFssnxBM5L3Ex7bmTKzetivOrFP25ztCd6Bu5RXaZ/KJgJlFoHqw8GkGp6iMb1bXcyOSlndJWYprHfa5XjbBsNmXwZ6y8AM3V8Qb+dzDeA60qmX5RlWQOp80W50QKh7BOBud0JuLewZE4JKiWUsM5Csisc/XZbYQSpWZTgGduqi1taYDOZHSPA/yJUtIqdXiyCwo5P0oIqKwIDAQAB\n-----END PUBLIC KEY-----\n")
+
 func reportsHandler(w http.ResponseWriter, r *http.Request) {
 	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" {
-		http.Error(w, "Authorization header is required", http.StatusUnauthorized)
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+
+	pubKey, err := jwt.ParseRSAPublicKeyFromPEM(publicKey)
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, "ERROR: "+err.Error())
 		return
 	}
 
-	//	ParseRSAPublicKeyFromPEM
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-			f _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}
-		return mySigningKey, nil
+		return pubKey, nil
 	})
 
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, "Token ERROR! " + err.Error())
+		fmt.Fprint(w, "Unauthorized - err: "+err.Error())
 		return
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
-		if claims["roles"] != "prothetic_user" {
+		if claims["realm_access"].(map[string]interface{})["roles"].([]interface{})[0] != "prothetic_user" {
 			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Fprint(w, "Target role not found!")
+			fmt.Fprint(w, "Unauthorized")
 			return
 		}
-		fmt.Fprint(w, "OK - WELCOME!")
+		fmt.Fprint(w, "Welcome!")
 	} else {
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, "Token not valid!")
+		fmt.Fprint(w, "Unauthorized")
 	}
-
 }

--- a/api/main.go
+++ b/api/main.go
@@ -41,9 +41,10 @@ func reportsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	//	ParseRSAPublicKeyFromPEM
 	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			f _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return mySigningKey, nil

--- a/api/main.go
+++ b/api/main.go
@@ -1,13 +1,45 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
 )
+
+type Realm struct {
+	PublicKey string `json:"public_key"`
+}
+
+var publicKey []byte
+var realmPK string
+
+func initRSAPublicKey() {
+	resp, err := http.Get("http://keycloak:8080/realms/reports-realm")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	var realm Realm
+	err = json.Unmarshal(body, &realm)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	realmPK = "\n-----BEGIN PUBLIC KEY-----\n" + realm.PublicKey + "\n-----END PUBLIC KEY-----\n"
+	publicKey = []byte("\n-----BEGIN PUBLIC KEY-----\n" + realm.PublicKey + "\n-----END PUBLIC KEY-----\n")
+}
 
 // CORSMiddleware добавляет необходимые заголовки для поддержки CORS
 func CORSMiddleware(next http.Handler) http.Handler {
@@ -32,16 +64,18 @@ func main() {
 	http.ListenAndServe(":8000", CORSMiddleware(r))
 }
 
-var publicKey = []byte("\n-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1mxs5cw/bOGQ+PHLFeIwDAUzGhKLDYbNJaqoHjvV/GUCAp/1FF/TDIiEN2fuLLeAgpPZKZSEG+bxXJ7vXXxSNvUjY1etmRvHbhlMN+rJYTQtWLZxsvM/MfYi0b+l20oeGtCBwUa2CKWFssnxBM5L3Ex7bmTKzetivOrFP25ztCd6Bu5RXaZ/KJgJlFoHqw8GkGp6iMb1bXcyOSlndJWYprHfa5XjbBsNmXwZ6y8AM3V8Qb+dzDeA60qmX5RlWQOp80W50QKh7BOBud0JuLewZE4JKiWUsM5Csisc/XZbYQSpWZTgGduqi1taYDOZHSPA/yJUtIqdXiyCwo5P0oIqKwIDAQAB\n-----END PUBLIC KEY-----\n")
+//var publicKey = []byte("\n-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzEd0L5pqlOVLuyrfWOVDmqn4MvsX8jn+k2Ea/Tsi7xxYysGQaCAvGa3TMdzTw69knyg9VUJTxPSxp2kJ4BRm5jVgEQb6v+44P2gcaEUjPpBgDyGYa2wHuZntjEbl63rF0lJjpjFO2HMw6wh4cOlQjHHnLAKBqw7TD3bXDDUWY2A16viB54vdeLXT+QqvaRBm4pZFRIwIg0V+SVo8yIuvcVdKDphq13d4P0Hf/EdeB4Reg2FKmHdRZwzCXDRqND/0EhC9OftEi53d/K2MPVK4JwH7Z8YrRyZtV+jraEXpaePzO6jDpDyNoLxaN0uAv6al9QY/6UVdmHHlaKtV4A12tQIDAQAB\n-----END PUBLIC KEY-----\n")
 
 func reportsHandler(w http.ResponseWriter, r *http.Request) {
+	initRSAPublicKey()
+
 	authHeader := r.Header.Get("Authorization")
 	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
 
-	pubKey, err := jwt.ParseRSAPublicKeyFromPEM(publicKey)
+	var pubKey, err = jwt.ParseRSAPublicKeyFromPEM(publicKey)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, "ERROR: "+err.Error())
+		fmt.Fprint(w, "ERROR: "+err.Error()+"- pk: "+realmPK)
 		return
 	}
 
@@ -51,10 +85,12 @@ func reportsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return pubKey, nil
 	})
+	/*
 
+	 */
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, "Unauthorized - err: "+err.Error())
+		fmt.Fprint(w, "Unauthorized - err: "+err.Error()+"- pk: "+realmPK)
 		return
 	}
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,3 @@ services:
       context: ./api
     ports:
       - "8000:8000"
-#    environment:
-#      APP_KEYCLOAK_URL: http://localhost:8080
-#      APP_KEYCLOAK_REALM: reports-realm
-#      APP_KEYCLOAK_CLIENT_ID: reports-api

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,8 +31,8 @@ services:
       - keycloak_db
   frontend:
     build:
-      context: ./frontend
       dockerfile: Dockerfile
+      context: ./frontend
     ports:
       - "3000:3000"
     environment:
@@ -40,3 +40,9 @@ services:
       REACT_APP_KEYCLOAK_URL: http://localhost:8080
       REACT_APP_KEYCLOAK_REALM: reports-realm
       REACT_APP_KEYCLOAK_CLIENT_ID: reports-frontend
+  api:
+    build:
+      dockerfile: Dockerfile
+      context: ./api
+    ports:
+      - "8000:8000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,3 +46,7 @@ services:
       context: ./api
     ports:
       - "8000:8000"
+#    environment:
+#      APP_KEYCLOAK_URL: http://localhost:8080
+#      APP_KEYCLOAK_REALM: reports-realm
+#      APP_KEYCLOAK_CLIENT_ID: reports-api

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '4.1'
 
 services:
   keycloak_db:
@@ -11,6 +11,8 @@ services:
       - ./postgres-keycloak-data:/var/lib/postgresql/data
     ports:
       - "5433:5432"
+    networks:
+      - my-network
   keycloak:
     image: quay.io/keycloak/keycloak:21.1
     environment:
@@ -29,6 +31,9 @@ services:
       - "8080:8080"
     depends_on:
       - keycloak_db
+    networks:
+      - my-network
+
   frontend:
     build:
       dockerfile: Dockerfile
@@ -40,9 +45,23 @@ services:
       REACT_APP_KEYCLOAK_URL: http://localhost:8080
       REACT_APP_KEYCLOAK_REALM: reports-realm
       REACT_APP_KEYCLOAK_CLIENT_ID: reports-frontend
+    networks:
+      - my-network
   api:
     build:
       dockerfile: Dockerfile
       context: ./api
     ports:
       - "8000:8000"
+#    depends_on:
+#     - keycloak
+    environment:
+      APP_KEYCLOAK_URL: http://localhost:8080
+      APP_KEYCLOAK_REALM: reports-realm
+      APP_KEYCLOAK_CLIENT_ID: reports-api
+    networks:
+      - my-network
+networks:
+  my-network:
+    driver: bridge
+#      external: true

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,10 +8,28 @@ server {
         try_files $uri $uri/ /index.html;
     }
     
+    location /reports {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
+  #        try_files /cache$uri $uri $uri/ @backend;
+    }
+
+#    location @backend {
+#        proxy_pass http://localhost:8000;
+#        proxy_set_header Host $host;
+#        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#        proxy_set_header X-Real-IP $remote_addr;
+#    }
+
     # Enable CORS
-    add_header 'Access-Control-Allow-Origin' '*';
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
+#    add_header 'Access-Control-Allow-Origin' '*';
+#    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+#    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
     
     error_page 500 502 503 504 /50x.html;
     location = /50x.html {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,8 +15,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         add_header 'Access-Control-Allow-Origin' '*';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
-  #        try_files /cache$uri $uri $uri/ @backend;
+        add_header 'Access-Control-Allow-Headers' 'Content-Type,Authorization';
+  #      add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
+  #      try_files /cache$uri $uri $uri/ @backend;
     }
 
 #    location @backend {

--- a/frontend/src/components/ReportPage.tsx
+++ b/frontend/src/components/ReportPage.tsx
@@ -18,7 +18,8 @@ const ReportPage: React.FC = () => {
 
       const response = await fetch(`${process.env.REACT_APP_API_URL}/reports`, {
         headers: {
-          'Authorization': `Bearer ${keycloak.token}`
+          'Authorization': `Bearer ${keycloak.token}`,
+          'Access-Control-Allow-Origin': `*`
         }
       });
 

--- a/frontend/src/components/ReportPage.tsx
+++ b/frontend/src/components/ReportPage.tsx
@@ -18,8 +18,8 @@ const ReportPage: React.FC = () => {
 
       const response = await fetch(`${process.env.REACT_APP_API_URL}/reports`, {
         headers: {
-          'Authorization': `Bearer ${keycloak.token}`,
-          'Access-Control-Allow-Origin': `*`
+          'Authorization': `Bearer ${keycloak.token}`
+      //  ,'Access-Control-Allow-Origin': `*`
         }
       });
 

--- a/frontend/src/components/ReportPage.tsx
+++ b/frontend/src/components/ReportPage.tsx
@@ -19,7 +19,6 @@ const ReportPage: React.FC = () => {
       const response = await fetch(`${process.env.REACT_APP_API_URL}/reports`, {
         headers: {
           'Authorization': `Bearer ${keycloak.token}`
-      //  ,'Access-Control-Allow-Origin': `*`
         }
       });
 


### PR DESCRIPTION
Добрый вечер!
Отправляю вам на проверку работу по спринту 8.

К сожалению, не получилось устранить 2 ошибки:
1. CORS-ы при вызове GET /reports
2. И возврат 401 ошибки по всем юзерам (включая группу "prothetic_user")

По 401 ошибке:
Она возникает при неуспехе
token, err := jwt.Parse(tokenString, func(token *jwt.Token)  
Не понимаю почему, так как секретный токен прописан в коде, на мой взгляд правильно, но корректного парсинга JWT не происходит.
Причина может быть в неверном секрете reports-api в keycloak, но (oNwoLQdvJAvRcL89SydqCWCe5ry1jMgq) - это секрет, который мы изначально загружаем в keycloak из файла "realm-export.json".